### PR TITLE
Fix `MD001/heading-increment/header-increment` rule violation in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use [polyfills](https://formatjs.io/docs/polyfills) for some outdated browsers.
 npm i solid-i18n
 ```
 
-#### Displaying Messages
+### Displaying Messages
 
 ```typescript jsx
 import { createI18n, I18nProvider, Text } from 'solid-i18n';
@@ -37,7 +37,7 @@ function App() {
 }
 ```
 
-#### Plural Formatting
+### Plural Formatting
 
 ```typescript jsx
 <Text
@@ -46,7 +46,7 @@ function App() {
 />
 ```
 
-#### Date Formatting
+### Date Formatting
 
 ```typescript jsx
 <Text
@@ -65,7 +65,7 @@ function App() {
 
 Note: use `{datetime, date}` for number or string values.
 
-#### Number Formatting
+### Number Formatting
 
 ```typescript jsx
 <Numeric
@@ -75,7 +75,7 @@ Note: use `{datetime, date}` for number or string values.
 />
 ```
 
-#### useI18n
+### useI18n
 
 ```typescript jsx
 import { useI18n } from 'solid-i18n';
@@ -93,7 +93,7 @@ function SomeComp() {
 }
 ```
 
-#### Define Messages
+### Define Messages
 
 ```typescript jsx
 import { useI18n, defineMessages } from 'solid-i18n';
@@ -108,7 +108,7 @@ function SomeComp() {
 }
 ```
 
-#### Using Presets
+### Using Presets
 
 ```typescript jsx
 import { createI18n, I18nProvider, Text } from 'solid-i18n';


### PR DESCRIPTION
This pull request addresses the `MD001/heading-increment/header-increment` violations in the document. The rule states that heading levels should only increment by one level at a time, for example, from `H2` to `H3`, instead of `H4`. This helps to maintain a clear and consistent structure of the document.

The following changes have been made to comply with the rule:
- Changed `H4` headings on lines 21, 40, 49, 68, 78, 96 and 111 to `H3` headings.

These changes will improve the readability and structure of the document. Please review and let me know if any further changes are required.