### PR TITLE
Add `index.ts` to `components` and refactor imports

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,4 @@
+export * from './DateTime';
+export * from './I18nProvider';
+export * from './Numeric';
+export * from './Text';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,19 +4,14 @@ import { createI18n as create } from 'i18n-mini';
 import type { I18nOptions } from 'i18n-mini';
 import type { I18n } from './types';
 
+export type { I18n, I18nOptions };
+
 export { defineMessages } from 'i18n-mini';
 export type { I18nPresets } from 'i18n-mini';
 
-export { I18nProvider } from './components/I18nProvider';
-export { Text } from './components/Text';
-export { Numeric } from './components/Numeric';
-export { DateTime } from './components/DateTime';
+export * from './components';
 export { useI18n } from './context';
 
-export type { TextProps } from './components/Text';
-export type { NumericProps } from './components/Numeric';
-export type { DateTimeProps } from './components/DateTime';
-export type { I18n } from './types';
 
 function formatTag(tag: string, child: string | string[] | undefined) {
   const el = template(`<${tag}>`);


### PR DESCRIPTION
This Pull Request addresses issue #5 by adding an `index.ts` file to the `components` folder that exports all the components. This simplifies importing them in other files and makes the code more consistent and maintainable.

In addition, the libraries `index.ts` file has been refactored to import from the components folder instead of each individual component file, like this:

```ts
export * from './components';
```

In addition to that, the `I18nOptions` has been exported as it's being used by the `createI18n` function.

This change should make it easier to work with the components and improve the overall code quality. Please let me know if you have any feedback or suggestions. Thank you! 😊